### PR TITLE
Fix: DS-129, Pass env id in context instead of scanning the DB

### DIFF
--- a/solutions/swb-app/src/environmentRoutes.ts
+++ b/solutions/swb-app/src/environmentRoutes.ts
@@ -142,7 +142,8 @@ export function setUpEnvRoutes(
 
       const context = {
         roleArn: environment.PROJ.envMgmtRoleArn,
-        externalId: environment.PROJ.externalId
+        externalId: environment.PROJ.externalId,
+        envId: req.params.id
       };
 
       if (environment.status !== 'COMPLETED') {

--- a/solutions/swb-reference/src/environment/ec2JupyterLab/ec2JupyterLabEnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2JupyterLab/ec2JupyterLabEnvironmentConnectionService.ts
@@ -9,7 +9,7 @@ import {
   EnvironmentConnectionLinkPlaceholder
 } from '@aws/workbench-core-environments';
 
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2JupyterLabEnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2JupyterLab';
@@ -42,7 +42,7 @@ export default class EC2JupyterLabEnvironmentConnectionService implements Enviro
   public async getJupyterLabUrl(instanceId: string, context?: any): Promise<string> {
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    const envId = context.envId;
     const accessToken = await this.getJupyterLabToken(instanceId, context);
     const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}/lab?token=${accessToken}`;
     return authorizedUrl;

--- a/solutions/swb-reference/src/environment/ec2JupyterLab350/ec2JupyterLab350EnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2JupyterLab350/ec2JupyterLab350EnvironmentConnectionService.ts
@@ -9,7 +9,7 @@ import {
   EnvironmentConnectionLinkPlaceholder
 } from '@aws/workbench-core-environments';
 
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2JupyterLab350EnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2JupyterLab350';
@@ -42,7 +42,7 @@ export default class EC2JupyterLab350EnvironmentConnectionService implements Env
   public async getJupyterLabUrl(instanceId: string, context?: any): Promise<string> {
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    const envId = context.envId;
     const accessToken = await this.getJupyterLabToken(instanceId, context);
     const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}/lab?token=${accessToken}`;
     return authorizedUrl;

--- a/solutions/swb-reference/src/environment/ec2Rstudio/ec2RstudioEnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2Rstudio/ec2RstudioEnvironmentConnectionService.ts
@@ -13,7 +13,7 @@ import {
 
 import NodeRSA = require('node-rsa');
 
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2RstudioEnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2Rstudio';
@@ -48,7 +48,7 @@ export default class EC2RstudioEnvironmentConnectionService implements Environme
     console.log(`JWT Secret - ${jwtSecret}`);
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    const envId = context.envId;
 
     // const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}`;
     const rstudioSignInUrl = `https://${this._envType}-${envId}.${partnerDomain}/auth-do-sign-in`;

--- a/solutions/swb-reference/src/environment/ec2Rstudio421/ec2Rstudio421EnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2Rstudio421/ec2Rstudio421EnvironmentConnectionService.ts
@@ -13,7 +13,7 @@ import {
 
 import NodeRSA = require('node-rsa');
 
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2Rstudio421EnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2Rstudio421';
@@ -48,7 +48,7 @@ export default class EC2Rstudio421EnvironmentConnectionService implements Enviro
     console.log(`JWT Secret - ${jwtSecret}`);
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    const envId = context.envId;
 
     // const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}`;
     const rstudioSignInUrl = `https://${this._envType}-${envId}.${partnerDomain}/auth-do-sign-in`;

--- a/solutions/swb-reference/src/environment/ec2Spyder/ec2SpyderEnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2Spyder/ec2SpyderEnvironmentConnectionService.ts
@@ -7,7 +7,7 @@ import {
   EnvironmentConnectionService,
   EnvironmentConnectionLinkPlaceholder
 } from '@aws/workbench-core-environments';
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2SpyderEnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2Spyder';
@@ -40,7 +40,8 @@ export default class EC2SpyderEnvironmentConnectionService implements Environmen
   public async getSpyderUrl(instanceId: string, context?: any): Promise<string> {
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    // const envId = context.envId;
+    const envId = context.envId;
     const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}/?authToken=${instanceId}#swb-session`;
     console.log(`URL - ${authorizedUrl}`);
     // const region = process.env.AWS_REGION!;

--- a/solutions/swb-reference/src/environment/ec2Spyder522/ec2Spyder522EnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2Spyder522/ec2Spyder522EnvironmentConnectionService.ts
@@ -7,7 +7,7 @@ import {
   EnvironmentConnectionService,
   EnvironmentConnectionLinkPlaceholder
 } from '@aws/workbench-core-environments';
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2Spyder522EnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2Spyder522';
@@ -40,7 +40,7 @@ export default class EC2Spyder522EnvironmentConnectionService implements Environ
   public async getSpyderUrl(instanceId: string, context?: any): Promise<string> {
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    const envId = context.envId;
     const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}/?authToken=${instanceId}#swb-session`;
     console.log(`URL - ${authorizedUrl}`);
     // const region = process.env.AWS_REGION!;

--- a/solutions/swb-reference/src/environment/ec2Stata/ec2StataEnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2Stata/ec2StataEnvironmentConnectionService.ts
@@ -7,7 +7,7 @@ import {
   EnvironmentConnectionService,
   EnvironmentConnectionLinkPlaceholder
 } from '@aws/workbench-core-environments';
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2StataEnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2Stata';
@@ -40,7 +40,7 @@ export default class EC2StataEnvironmentConnectionService implements Environment
   public async getSpyderUrl(instanceId: string, context?: any): Promise<string> {
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    const envId = context.envId;
     const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}/?authToken=${instanceId}#swb-session`;
     console.log(`URL - ${authorizedUrl}`);
     // const region = process.env.AWS_REGION!;

--- a/solutions/swb-reference/src/environment/ec2VSCode/ec2VSCodeEnvironmentConnectionService.ts
+++ b/solutions/swb-reference/src/environment/ec2VSCode/ec2VSCodeEnvironmentConnectionService.ts
@@ -9,7 +9,7 @@ import {
   EnvironmentConnectionLinkPlaceholder
 } from '@aws/workbench-core-environments';
 
-import { getEnvIdFromInstanceId } from '../envUtils';
+//import { getEnvIdFromInstanceId } from '../envUtils';
 
 export default class EC2VSCodeEnvironmentConnectionService implements EnvironmentConnectionService {
   private _envType: string = 'ec2VSCode';
@@ -42,7 +42,7 @@ export default class EC2VSCodeEnvironmentConnectionService implements Environmen
   public async getVSCodeUrl(instanceId: string, context?: any): Promise<string> {
     const secureConnectionMetadata = JSON.parse(process.env.SECURE_CONNECTION_METADATA!);
     const { partnerDomain } = secureConnectionMetadata;
-    const envId = await getEnvIdFromInstanceId(instanceId);
+    const envId = context.envId;
     const authorizedUrl = `https://${this._envType}-${envId}.${partnerDomain}`;
     return authorizedUrl;
   }

--- a/solutions/swb-reference/src/environment/envUtils.ts
+++ b/solutions/swb-reference/src/environment/envUtils.ts
@@ -59,16 +59,16 @@ async function deleteRoute53Record(applicationUrl: string, secureConnectionMetad
   }
 }
 
-async function getEnvIdFromInstanceId(instanceId: string): Promise<string> {
-  const aws = new AwsService({ region: process.env.AWS_REGION!, ddbTableName: process.env.STACK_NAME! });
-  const ddbService = aws.helpers.ddb;
-  const scanner = ddbService.scan({
-    filter: 'instanceId = :val',
-    values: { ':val': `${instanceId}` }
-  });
-  const response = await scanner.execute();
-  return `${response!.Items![0].id!}`;
-}
+// async function getEnvIdFromInstanceId(instanceId: string): Promise<string> {
+//   const aws = new AwsService({ region: process.env.AWS_REGION!, ddbTableName: process.env.STACK_NAME! });
+//   const ddbService = aws.helpers.ddb;
+//   const scanner = ddbService.scan({
+//     filter: 'instanceId = :val',
+//     values: { ':val': `${instanceId}` }
+//   });
+//   const response = await scanner.execute();
+//   return `${response!.Items![0].id!}`;
+// }
 
 async function getPendingEnvironmentsCount(): Promise<number> {
   const aws = new AwsService({ region: process.env.AWS_REGION!, ddbTableName: process.env.STACK_NAME! });
@@ -139,4 +139,4 @@ async function getElbSDKForRole(params: {
   }
 }
 
-export { calculateRulePriority, createRoute53Record, deleteRoute53Record, getEnvIdFromInstanceId };
+export { calculateRulePriority, createRoute53Record, deleteRoute53Record };


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fix: DS-129, Pass env id in context instead of scanning the DB

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.